### PR TITLE
Add allowed HTTPS domains to VPC security policy

### DIFF
--- a/dcf/main.tf
+++ b/dcf/main.tf
@@ -3,7 +3,7 @@ locals {
   "aviatrix.com",
   "*.amazonaws.com",
   "cloud.google.com",
-  "*.microsoft.com"l
+  "*.microsoft.com"
 ]
 }
 

--- a/dcf/main.tf
+++ b/dcf/main.tf
@@ -3,7 +3,7 @@ locals {
   "aviatrix.com",
   "*.amazonaws.com",
   "cloud.google.com",
-  "*.microsoft.com"
+  "*.microsoft.com"l
 ]
 }
 

--- a/dcf/main.tf
+++ b/dcf/main.tf
@@ -1,5 +1,10 @@
 locals {
-  allowed_https_domains = []
+  allowed_https_domains = [
+  "aviatrix.com",
+  "*.amazonaws.com",
+  "cloud.google.com",
+  "*.microsoft.com"
+]
 }
 
 resource "aviatrix_web_group" "allow_internet_https" {

--- a/lab1/main.tf
+++ b/lab1/main.tf
@@ -11,7 +11,7 @@ module "us_east_1_spoke" {
   account          = var.account_name_aws
   ha_gw            = false
   attached         = false
-  single_ip_snat   = false
+  single_ip_snat   = true
 }
 
 module "us_west_2_spoke" {
@@ -27,5 +27,5 @@ module "us_west_2_spoke" {
   account          = var.account_name_aws
   ha_gw            = false
   attached         = false
-  single_ip_snat   = false
+  single_ip_snat   = true
 }


### PR DESCRIPTION
Configure VPC egress policy to allow HTTPS traffic to specified domains:
   - aviatrix.com
   - *.amazonaws.com
   - cloud.google.com
   - *.microsoft.com
   
   This replaces the allow-all policy with a restrictive allow-internet policy.