### PR TITLE
Lab2 - Allows Egress to specified domains

### DIFF
--- a/dcf/main.tf
+++ b/dcf/main.tf
@@ -1,5 +1,10 @@
 locals {
-  allowed_https_domains = []
+  allowed_https_domains = [
+    "aviatrix.com",
+    "*.amazonaws.com",
+    "cloud.google.com",
+    "*.microsoft.com"
+  ]
 }
 
 resource "aviatrix_web_group" "allow_internet_https" {

--- a/lab1/main.tf
+++ b/lab1/main.tf
@@ -11,7 +11,7 @@ module "us_east_1_spoke" {
   account          = var.account_name_aws
   ha_gw            = false
   attached         = false
-  single_ip_snat   = false
+  single_ip_snat   = true
 }
 
 module "us_west_2_spoke" {
@@ -27,5 +27,5 @@ module "us_west_2_spoke" {
   account          = var.account_name_aws
   ha_gw            = false
   attached         = false
-  single_ip_snat   = false
+  single_ip_snat   = true
 }


### PR DESCRIPTION
Adding these to allowed:

    "aviatrix.com",
    "*.amazonaws.com",
    "cloud.google.com",
    "*.microsoft.com"